### PR TITLE
avoid storing peers who already exist on the server. 

### DIFF
--- a/server/src/simple-signal-server.js
+++ b/server/src/simple-signal-server.js
@@ -60,7 +60,7 @@ SimpleSignalServer.prototype._onDiscover = function (socket, metadata) {
     }
   })
 
-  if (!self.peers.include(socket.id)) {
+  if (self.peers.indexOf(socket.id) === -1) {
     self.peers.push(socket.id)
   }
 }

--- a/server/src/simple-signal-server.js
+++ b/server/src/simple-signal-server.js
@@ -59,7 +59,10 @@ SimpleSignalServer.prototype._onDiscover = function (socket, metadata) {
       })
     }
   })
-  self.peers.push(socket.id)
+
+  if (!self.peers.include(socket.id)) {
+    self.peers.push(socket.id)
+  }
 }
 
 SimpleSignalServer.prototype._onOffer = function (socket, data) {


### PR DESCRIPTION
A peer could fire a rediscover event from the client, in this case it would exist already on the server with the same socket id and should not be stored again in the peers array.