### PR TITLE
Use `socket.to` to work with socket.io-redis

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -46,8 +46,7 @@ SimpleSignalServer.prototype._onDiscover = function (socket, discoveryData) {
 SimpleSignalServer.prototype._onOffer = function (socket, { sessionId, signal, target, metadata }) {
   const request = { initiator: socket.clientId, target, metadata, socket }
   request.forward = (target=request.target, metadata=request.metadata) => {
-    if (!this._sockets[target]) return
-    this._sockets[target].emit('simple-signal[offer]', {
+    socket.to(target).emit('simple-signal[offer]', {
       initiator: socket.clientId, sessionId, signal, metadata
     })
   }
@@ -60,19 +59,15 @@ SimpleSignalServer.prototype._onOffer = function (socket, { sessionId, signal, t
 }
 
 SimpleSignalServer.prototype._onSignal = function (socket, { target, sessionId, signal, metadata }) {
-  if (!this._sockets[target]) return
-
   // misc. signaling data is always forwarded
-  this._sockets[target].emit('simple-signal[signal]', {
+  socket.to(target).emit('simple-signal[signal]', {
     sessionId, signal, metadata
   })
 }
 
 SimpleSignalServer.prototype._onReject = function (socket, { target, sessionId, metadata }) {
-  if (!this._sockets[target]) return
-
   // rejections are always forwarded
-  this._sockets[target].emit('simple-signal[reject]', {
+  socket.to(target).emit('simple-signal[reject]', {
     sessionId, metadata
   })
 }


### PR DESCRIPTION
When distributing across different nodes, keeping a local list of sockets will be unreliable since a client connected to a server in say, Asia, will not show up in the socket list of the server in Europe, and so any clients connecting to the Europe server will be unable to connect to clients connected to the Asia server.

One way around this is to use an adapter that communicates pub/sub between socket nodes, for example `socket.io-redis`. However when doing this, only the pub/sub events are propagated, basically the `.on` and `.emit`. As a result when using `simple-signal-server` across different nodes, all other socket events fire but the connection does not.

To fix this, it would suffice to change all occurrences of `this._sockets[target]` to `socket.to(target)` and remove the checking of whether the socket is currently connected: `if (!this._sockets[target]) return`.

This pull request does exactly that. **However, I don't think it should be merged as it is.** Removing the `if (!this._sockets[target]) return` lines means there is no longer a way to check if the socket is connected. [As far as I know](https://github.com/socketio/socket.io-redis/issues/277) this is not currently possible using adapters.

Since Socket.io 2 focuses on rooms, I've handled disconnections and etc through checking the room client list (`io.in(room).clients((err, clients) => { /* handler */})`). I would propose a larger change to how signalling is handled, moving from keeping a list of sockets to working with rooms by themselves -- every socket joins a room under its own ID in Socket.io 2 so this also works with individual clients.

For now, I've put up a fork compatible with `socket.io-redis` [here](https://github.com/pshah123/simple-signal) which can be installed via `npm install pshah123/simple-signal#2.1.2` for the server.